### PR TITLE
Accept numpy uint32 in SZ.from_flat and add unit test

### DIFF
--- a/pyblock3/algebra/symmetry.py
+++ b/pyblock3/algebra/symmetry.py
@@ -42,6 +42,7 @@ class SZ:
 
     @staticmethod
     def from_flat(x):
+        x = int(x)
         return SZ((x // 131072) % 16384 - 8192, (x // 8) % 16384 - 8192, x % 8)
 
     @staticmethod
@@ -273,4 +274,3 @@ class BondFusingInfo(BondInfo):
             finfo[q][k] = quanta[q], v
             quanta[q] += v
         return BondFusingInfo(quanta, finfo=finfo, pattern='+')
-

--- a/pyblock3/algebra/tests/test_symmetry.py
+++ b/pyblock3/algebra/tests/test_symmetry.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 from pyblock3.algebra.fermion_symmetry import U11, U1, Z4, Z2, Z22
+from pyblock3.algebra.symmetry import SZ
 from itertools import product
 
 class TestAlgebras(unittest.TestCase):
@@ -69,6 +70,14 @@ class TestAlgebras(unittest.TestCase):
             u1a = U1(z)
             u1b = U1.from_flat(u1a.to_flat())
             assert u1a==u1b
+
+    def test_sz_from_flat_uint32(self):
+        sym = SZ(n=-1, twos=-3, pg=5)
+        flat = np.uint32(sym.to_flat())
+        out = SZ.from_flat(flat)
+        assert out.n == -1
+        assert out.twos == -3
+        assert out.pg == 5
 
     def test_U11_compute(self):
         ndim = 10


### PR DESCRIPTION
### Motivation
- Ensure `SZ.from_flat` can accept numpy integer scalars (e.g. `np.uint32`) when decoding flattened quantum-number values to avoid type issues.

### Description
- Coerce the input to an integer in `SZ.from_flat` by adding `x = int(x)` before decoding. 
- Import `SZ` into the symmetry tests and add `test_sz_from_flat_uint32` which round-trips a flattened value stored as `np.uint32` through `SZ.from_flat`.

### Testing
- Ran the symmetry unit tests in `pyblock3.algebra.tests.test_symmetry`, including the new `test_sz_from_flat_uint32`, using the test runner; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bad7f884648325a08602701de4f13d)